### PR TITLE
Add DCOM Port Range Settings to match Particular Docs

### DIFF
--- a/src/NServiceBus.PowerShell/Cmdlets/InstallDtc.cs
+++ b/src/NServiceBus.PowerShell/Cmdlets/InstallDtc.cs
@@ -1,16 +1,28 @@
 ﻿namespace NServiceBus.PowerShell
 {
+    using System;
     using System.Management.Automation;
     using Helpers;
+    using System.Text.RegularExpressions;
 
     [Cmdlet(VerbsLifecycle.Install, "NServiceBusDTC", SupportsShouldProcess = true)]
     public class InstallDtc : CmdletBase
     {
+        [Parameter(Mandatory = false, HelpMessage = "Port Range to use for DCOM Config. The format should be two numbers separated by a dash. e.g. \"5000-6000\"")]
+        public string PortRange { get; set; }
+
         protected override void ProcessRecord()
         {
+            if (!StringExtensions.IsNullOrWhiteSpace(PortRange)) 
+            {
+                var portRangeRegex = new Regex(@"^[0-9]+\-[0-9]+$");
+                var match = portRangeRegex.Match(PortRange);
+                if(!match.Success) this.ThrowTerminatingError(new ErrorRecord(new Exception("Invalid value for PortRange parameter. The format should be two numbers separated by a dash. e.g. \"5000-6000\""),"1",ErrorCategory.InvalidArgument, "" ));
+            }
+            
             if (ShouldProcess(EnvironmentHelper.MachineName))
             {
-                new DtcSetup(Host).StartDtcIfNecessary();
+                new DtcSetup(Host).StartDtcIfNecessary(PortRange);
             }
         }
     }

--- a/src/NServiceBus.PowerShell/Helpers/RegistryHelper.cs
+++ b/src/NServiceBus.PowerShell/Helpers/RegistryHelper.cs
@@ -446,6 +446,12 @@ namespace NServiceBus.PowerShell.Helpers
                         var data = value.ToString();
                         return RegSetValueEx(regKeyHandle, valueName, 0, valueKind, data, checked(data.Length * 2 + 2)) == 0;
                     }
+                    case RegistryValueKind.MultiString:
+                    {
+                        String[] stringsList = (String[]) value;
+                        var data = String.Join("\0", stringsList) + "\0\0";
+                        return RegSetValueEx(regKeyHandle, valueName, 0, valueKind, data, checked(data.Length * 2 + 2)) == 0;
+                    }
                     case RegistryValueKind.Binary:
                     {
                         var dataBytes = (byte[]) value;

--- a/src/NServiceBus.PowerShell/NServiceBus.PowerShell.dll-help.xml
+++ b/src/NServiceBus.PowerShell/NServiceBus.PowerShell.dll-help.xml
@@ -87,12 +87,19 @@
 		<dev:version />
 	</command:details>
 	<maml:description>
-		<maml:para>This cmdlet will configure and attempt to start the Microsoft Distributed Transaction Co-ordinator service on this machine.  To configure MSDTC with NServiceBus the cmdlet sets the following values under the 
+		<maml:para>This cmdlet will configure and attempt to start the Microsoft Distributed Transaction Coordinator service on this machine.  To configure MSDTC with NServiceBus the cmdlet sets the following values under the 
 &quot;HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSDTC\Security&quot; registry key:</maml:para>
 		<maml:para>NetworkDtcAccess : 1 (DWORD)
+NetworkDtcAccessInbound : 1 (DWORD)
 NetworkDtcAccessOutbound : 1 (DWORD)
 NetworkDtcAccessTransactions: 1 (DWORD)
-XaTransactions : 1 (DWORD)</maml:para>
+XaTransactions : 1 (DWORD)
+NetworkDtcAccessClients : 1 (DWORD)</maml:para>
+    <maml:para>If the optional PortRange parameter is supplied, then this value will be used for the DCOM Configuration. The format should be two numbers separated by a dash. (e.g. &quot;5000-6000&quot;). Specifically, the cmdlet will set the following values under the 
+&quot;HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Rpc\Internet&quot; registry key:</maml:para>
+    <maml:para>Ports : [Based on value of PortRange parameter] (Multi-String Value)
+PortsInternetAvailable : "Y" (String Value)    
+UseInternetPorts : "Y" (String Value)</maml:para>
 	</maml:description>
 	<command:syntax>
 		<command:syntaxItem>
@@ -113,8 +120,20 @@ XaTransactions : 1 (DWORD)</maml:para>
 			</command:parameter>
 		</command:syntaxItem>
 	</command:syntax>
-	<command:parameters>
-		<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+  <command:parameters>
+    <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
+      <maml:name>PortRange</maml:name>
+      <maml:description>
+        <maml:para />
+      </maml:description>
+      <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+      <dev:type>
+        <maml:name>String</maml:name>
+        <maml:uri/>
+      </dev:type>
+      <dev:defaultValue></dev:defaultValue>
+    </command:parameter>
+    <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
 			<maml:name>WhatIf</maml:name>
 			<maml:description>
 				<maml:para />


### PR DESCRIPTION
[According to the Particular Docs](http://docs.particular.net/nservicebus/operations/transactions-message-processing), the Port Ranges in the "Component
Services" / "Properties for COM Internet Services" dialog should be set
to "5000-6000".

This changeset will update the install-NServiceBusDTC PowerShell cmdlet,
so that it will set these Port Range settings to the recommended values.

This is to resolve issue #28 