### PR TITLE
Add LicenseString parameter to InstallPlatformLicense

### DIFF
--- a/src/NServiceBus.PowerShell/Cmdlets/InstallPlatformLicense.cs
+++ b/src/NServiceBus.PowerShell/Cmdlets/InstallPlatformLicense.cs
@@ -7,13 +7,15 @@
     using Microsoft.Win32;
     using Helpers;
 
-    [Cmdlet(VerbsLifecycle.Install, "NServiceBusPlatformLicense")]
+    [Cmdlet(VerbsLifecycle.Install, "NServiceBusPlatformLicense", DefaultParameterSetName = "ByLicenseFile")]
     public class InstallPlatformLicense : CmdletBase
     {
-        [Parameter(Mandatory = false, HelpMessage = "Platform license file to import", Position = 0)]
+        [Parameter(Mandatory = true, HelpMessage = "Platform license file to import", Position = 0, ParameterSetName = "ByLicenseFile")]
+        [ValidateNotNullOrEmpty]
         public string LicenseFile { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Platform license string to import", Position = 1)]
+        [Parameter(Mandatory = true, HelpMessage = "Platform license string to import", Position = 0, ParameterSetName = "ByLicenseString")]
+        [ValidateNotNullOrEmpty]
         public string LicenseString { get; set; }
 
         protected override void ProcessRecord()
@@ -22,7 +24,7 @@
             string content;
 
             // LicenseFile primary option
-            if(!string.IsNullOrEmpty(LicenseFile))
+            if(ParameterSetName.Equals("ByLicenseFile"))
             {
                 ProviderInfo provider;
                 PSDriveInfo drive;
@@ -47,7 +49,7 @@
                 }
             }
             // LicenseString secondary option
-            else if (!string.IsNullOrEmpty(LicenseString))
+            else
             {
                 content = LicenseString;
                 if (!CheckFileContentIsALicenseFile(content))
@@ -57,14 +59,6 @@
                     WriteError(error);
                     return;
                 }
-            }
-            // No valid parameter supplied
-            else
-            {
-                var ex = new ArgumentException("LicenseFile or LicenseString must be provided.");
-                var error = new ErrorRecord(ex, "InvalidParameter", ErrorCategory.InvalidArgument, null);
-                WriteError(error);
-                return;
             }
 
             if (EnvironmentHelper.Is64BitOperatingSystem)

--- a/src/NServiceBus.PowerShell/NServiceBus.PowerShell.dll-help.xml
+++ b/src/NServiceBus.PowerShell/NServiceBus.PowerShell.dll-help.xml
@@ -988,13 +988,19 @@ XaTransactions : 1 (DWORD)</maml:para>
 		<dev:version />
 	</command:details>
 	<maml:description>
-		<maml:para>Imports the the Particular Platform License into the registry.  For 64-bit operating systems the license is written to both the 32-bit and 64-bit registry.</maml:para>
+		<maml:para>Imports the the Particular Platform License into the registry.  For 64-bit operating systems the license is written to both the 32-bit and 64-bit registry. Provide either LicenseFile or LicenseString.</maml:para>
 	</maml:description>
 	<command:syntax>
 		<command:syntaxItem>
 			<maml:name>Install-NServiceBusPlatformLicense</maml:name>
-			<command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="0">
+			<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="0">
 				<maml:name>LicenseFile</maml:name>
+				<maml:description>
+					<maml:para />
+				</maml:description>
+				<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+			</command:parameter><command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="1">
+				<maml:name>LicenseString</maml:name>
 				<maml:description>
 					<maml:para />
 				</maml:description>
@@ -1003,8 +1009,20 @@ XaTransactions : 1 (DWORD)</maml:para>
 		</command:syntaxItem>
 	</command:syntax>
 	<command:parameters>
-		<command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="0">
+		<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="0">
 			<maml:name>LicenseFile</maml:name>
+			<maml:description>
+				<maml:para />
+			</maml:description>
+			<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+			<dev:type>
+				<maml:name>String</maml:name>
+				<maml:uri/>
+			</dev:type>
+			<dev:defaultValue></dev:defaultValue>
+		</command:parameter>
+    <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="1">
+			<maml:name>LicenseString</maml:name>
 			<maml:description>
 				<maml:para />
 			</maml:description>

--- a/src/NServiceBus.PowerShell/NServiceBus.PowerShell.dll-help.xml
+++ b/src/NServiceBus.PowerShell/NServiceBus.PowerShell.dll-help.xml
@@ -993,13 +993,16 @@ XaTransactions : 1 (DWORD)</maml:para>
 	<command:syntax>
 		<command:syntaxItem>
 			<maml:name>Install-NServiceBusPlatformLicense</maml:name>
-			<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="0">
+			<command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="0">
 				<maml:name>LicenseFile</maml:name>
 				<maml:description>
 					<maml:para />
 				</maml:description>
 				<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-			</command:parameter><command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="1">
+			</command:parameter>
+    </command:syntaxItem>
+    <command:syntaxItem>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="0">
 				<maml:name>LicenseString</maml:name>
 				<maml:description>
 					<maml:para />
@@ -1009,7 +1012,7 @@ XaTransactions : 1 (DWORD)</maml:para>
 		</command:syntaxItem>
 	</command:syntax>
 	<command:parameters>
-		<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="0">
+		<command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="0">
 			<maml:name>LicenseFile</maml:name>
 			<maml:description>
 				<maml:para />
@@ -1021,7 +1024,7 @@ XaTransactions : 1 (DWORD)</maml:para>
 			</dev:type>
 			<dev:defaultValue></dev:defaultValue>
 		</command:parameter>
-    <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="1">
+    <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="false" position="0">
 			<maml:name>LicenseString</maml:name>
 			<maml:description>
 				<maml:para />


### PR DESCRIPTION
The InstallPlatformLicense cmdlet only supported importing a license from a file. This adds support to import a license from a string

Requested in Issue #34 