### PR TITLE
All branches on GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,8 @@ on:
   push:
     branches:
       - master
-      - release-[6-9].*
+      - release-*
   pull_request:
-    branches-ignore:
-      - release-[0-5].*
   workflow_dispatch:
 env:
   DOTNET_NOLOGO: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 on:
   push:
     tags:
-      - '[6-9].[0-9]+.[0-9]+'
-      - '[6-9].[0-9]+.[0-9]+-*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 env:
   DOTNET_NOLOGO: true
   RELEASE_WORKFLOW: true


### PR DESCRIPTION
Removed release-5.3 branch, it's 4+ years old, can't be supportable. All branches (master and release-6) will be on GitHub Actions and TeamCity will be disabled.